### PR TITLE
HA Template: Custom sensors for Pulse Input A & B Volume

### DIFF
--- a/modules/data/homeassistant_mappings/kamstrup_multical_401.json
+++ b/modules/data/homeassistant_mappings/kamstrup_multical_401.json
@@ -97,5 +97,23 @@
         "platform": "sensor",
         "value_template":"{{ value_json.manufacturer_specific }}",
         "entity_category": "diagnostic"
+    },
+    "custom-pulse_input_a_volume": {
+        "name": "Pulse Input A: Volume",
+        "icon": "mdi:counter",
+        "platform": "sensor",
+        "value_template": "{% set data = value_json.manufacturer_specific %} {{ data.split()[30:34] | reverse | join('') | int / 100 | round(2) }}",
+        "device_class": "water",
+        "unit_of_measurement": "m³",
+        "state_class": "TOTAL_INCREASING"
+    },
+    "custom-pulse_input_b_volume": {
+        "name": "Pulse Input B: Volume",
+        "icon": "mdi:counter",
+        "platform": "sensor",
+        "value_template": "{% set data = value_json.manufacturer_specific %} {{ data.split()[34:38] | reverse | join('') | int / 100 | round(2) }}",
+        "device_class": "water",
+        "unit_of_measurement": "m³",
+        "state_class": "TOTAL_INCREASING"
     }
 }


### PR DESCRIPTION
Based on discussion in https://github.com/nilvanis/libmbus2mqtt/issues/4 and information from [official MULTICAL M-Bus documentation](https://documentation.kamstrup.com/docs/M_Bus_for_MULTICAL_401/en-GB/Technical_description/CONT07A5D5B545094AF882090FC1F28C9DB2/), two custom sensors were added with values derived from part of `Manufacturer Specific` data.